### PR TITLE
fix(ci): format for SwiftFormat 0.60 and make the list's key-window observer closure Sendable

### DIFF
--- a/Sources/WaterUI/Components/Controls/WuiDatePicker.swift
+++ b/Sources/WaterUI/Components/Controls/WuiDatePicker.swift
@@ -220,7 +220,6 @@ final class WuiDatePicker: PlatformView, WuiComponent {
     #endif
 
     NSLayoutConstraint.activate(constraints)
-
   }
 
   #if canImport(UIKit)

--- a/Sources/WaterUI/Components/Controls/WuiProgress.swift
+++ b/Sources/WaterUI/Components/Controls/WuiProgress.swift
@@ -487,7 +487,7 @@ final class WuiProgress: PlatformView, WuiComponent {
   }
 
   private func applyValue(_ value: Double, metadata: WuiWatcherMetadata?) {
-    guard value == .infinity || (value.isFinite && (0...1).contains(value)) else {
+    guard value == .infinity || (value.isFinite && (0 ... 1).contains(value)) else {
       fatalError("Progress value must be finite within 0...1 or positive infinity")
     }
     let isIndeterminate = value == .infinity

--- a/Sources/WaterUI/Components/Graphics/WuiViewRenderer.swift
+++ b/Sources/WaterUI/Components/Graphics/WuiViewRenderer.swift
@@ -632,8 +632,8 @@ private func drawGpuSurface(
       from: MTLRegionMake2D(0, 0, Int(pixelWidth), Int(pixelHeight)),
       mipmapLevel: 0
     )
-    for index in 0..<(Int(pixelWidth) * Int(pixelHeight)) {
-      for channel in 0..<4 {
+    for index in 0 ..< (Int(pixelWidth) * Int(pixelHeight)) {
+      for channel in 0 ..< 4 {
         let value = Float(Float16(bitPattern: floatPixels[index * 4 + channel]))
         pixelBytes[index * 4 + channel] = UInt8(clamping: Int(value * 255))
       }
@@ -650,7 +650,7 @@ private func drawGpuSurface(
       from: MTLRegionMake2D(0, 0, Int(pixelWidth), Int(pixelHeight)),
       mipmapLevel: 0
     )
-    for index in 0..<(Int(pixelWidth) * Int(pixelHeight)) {
+    for index in 0 ..< (Int(pixelWidth) * Int(pixelHeight)) {
       pixelBytes[index * 4] = bgraPixels[index * 4 + 2]
       pixelBytes[index * 4 + 1] = bgraPixels[index * 4 + 1]
       pixelBytes[index * 4 + 2] = bgraPixels[index * 4]

--- a/Sources/WaterUI/Components/Layout/WuiContainer.swift
+++ b/Sources/WaterUI/Components/Layout/WuiContainer.swift
@@ -237,7 +237,6 @@ final class WuiContainer: PlatformView, WuiComponent {
     #endif
   }
 
-
   // A layout container is not a control: a click none of its children want
   // belongs to whatever is behind it.
   //
@@ -567,7 +566,7 @@ final class WuiContainer: PlatformView, WuiComponent {
     var cursor = window.leadingOffset
     var needsInvalidation = false
 
-    for index in window.start..<window.end {
+    for index in window.start ..< window.end {
       let id = itemIds[index]
       let child = renderedChildren[id] ?? anyViews.getView(at: index, env: env)
       if renderedChildren[id] == nil {

--- a/Sources/WaterUI/Components/Layout/WuiFixedContainer.swift
+++ b/Sources/WaterUI/Components/Layout/WuiFixedContainer.swift
@@ -63,7 +63,6 @@ final class WuiFixedContainer: PlatformView, WuiComponent {
 
   // MARK: - WuiComponent
 
-
   // A layout container is not a control: a click none of its children want
   // belongs to whatever is behind it.
   //

--- a/Sources/WaterUI/Components/Layout/WuiList.swift
+++ b/Sources/WaterUI/Components/Layout/WuiList.swift
@@ -162,7 +162,7 @@ private func computeListSectionGroups(
     )
   }
 
-  for i in 0..<count {
+  for i in 0 ..< count {
     if let info = peekListItemSection(from: contents, at: i) {
       flush()
       pendingLabel = info.label
@@ -189,7 +189,7 @@ private func resolveListSectionGroups(
     ListSectionGroup(
       label: nil,
       footer: nil,
-      itemIndices: Array(0..<count)
+      itemIndices: Array(0 ..< count)
     )
   ]
 }
@@ -905,7 +905,6 @@ private func singleSectionRowDiff(old: [Int32], new: [Int32])
           view.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
       }
-
     }
   }
 
@@ -1048,9 +1047,13 @@ private func singleSectionRowDiff(old: [Int32], new: [Int32])
       }
       keyWindowObservers = []
       guard let window else { return }
-      let repaint: (Notification) -> Void = { [weak self] _ in
-        self?.tableView.enumerateAvailableRowViews { rowView, _ in
-          rowView.needsDisplay = true
+      // Delivered on `.main`, so the hop is a statement of fact the compiler
+      // cannot see through the `@Sendable` requirement on its own.
+      let repaint: @Sendable (Notification) -> Void = { [weak self] _ in
+        MainActor.assumeIsolated {
+          self?.tableView.enumerateAvailableRowViews { rowView, _ in
+            rowView.needsDisplay = true
+          }
         }
       }
       for name in [NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification] {
@@ -1278,7 +1281,7 @@ private func singleSectionRowDiff(old: [Int32], new: [Int32])
         fatalError("WuiList requires one NSTableColumn")
       }
       column.width = width
-      tableView.noteHeightOfRows(withIndexesChanged: IndexSet(integersIn: 0..<flatLayout.count))
+      tableView.noteHeightOfRows(withIndexesChanged: IndexSet(integersIn: 0 ..< flatLayout.count))
       tableView.reloadData()
     }
 

--- a/Sources/WaterUI/Components/Layout/WuiTable.swift
+++ b/Sources/WaterUI/Components/Layout/WuiTable.swift
@@ -262,7 +262,7 @@ final class WuiTable: PlatformView, WuiComponent {
 
   private func rowHeights() -> [CGFloat] {
     let count = columns.map { $0.rows.ordered.count }.max() ?? 0
-    return (0..<count).map { rowIndex in
+    return (0 ..< count).map { rowIndex in
       max(
         28,
         (columns.compactMap { column in

--- a/Sources/WaterUI/Components/Media/WuiMapView.swift
+++ b/Sources/WaterUI/Components/Media/WuiMapView.swift
@@ -244,7 +244,6 @@ final class WuiMapViewComponent: PlatformView, WuiComponent {
     // Add map view as subview using manual frame layout
     mapView.translatesAutoresizingMaskIntoConstraints = true
     addSubview(mapView)
-
   }
 
   private func applySuppliedLocation(_ location: WuiSuppliedLocation?) {
@@ -290,7 +289,7 @@ final class WuiMapViewComponent: PlatformView, WuiComponent {
 
   private func reconcileAnnotations(_ values: [WuiNativeMapAnnotation]) {
     let reusedCount = min(renderedAnnotations.count, values.count)
-    for index in 0..<reusedCount {
+    for index in 0 ..< reusedCount {
       apply(values[index], to: renderedAnnotations[index])
     }
 

--- a/Sources/WaterUI/Components/Media/WuiVideoPlaybackCoordinator.swift
+++ b/Sources/WaterUI/Components/Media/WuiVideoPlaybackCoordinator.swift
@@ -1170,7 +1170,7 @@ final class WuiVideoPlaybackCoordinator: WuiMediaSessionHost {
 
   private func updateVolume(_ volume: Float) {
     precondition(
-      volume.isFinite && (0...1).contains(volume),
+      volume.isFinite && (0 ... 1).contains(volume),
       "video volume must be finite and within 0.0...1.0"
     )
     requestedVolume = volume

--- a/Sources/WaterUI/Components/Media/WuiWebView.swift
+++ b/Sources/WaterUI/Components/Media/WuiWebView.swift
@@ -116,7 +116,6 @@ final class WebViewWrapper: NSObject, WKScriptMessageHandler {
     }
   }
 
-
   private static let messageReplyCallback:
     @convention(c) (
       UnsafeMutableRawPointer?,
@@ -761,7 +760,7 @@ extension WebViewWrapper: WKNavigationDelegate {
       }
 
       let statusCode = response.statusCode
-      guard (300..<400).contains(statusCode) else {
+      guard (300 ..< 400).contains(statusCode) else {
         decisionHandler(.allow)
         return
       }

--- a/Sources/WaterUI/Components/Metadata/Interaction/WuiAccessibilityMetadata.swift
+++ b/Sources/WaterUI/Components/Metadata/Interaction/WuiAccessibilityMetadata.swift
@@ -125,7 +125,7 @@ final class WuiAccessibilityRole: WuiAccessibilityMetadataView, WuiComponent {
       case 22: .menuItem
       case 23: .menuBar
       case 26: .comboBox
-      case 5...10, 12, 15, 20, 27, 28: .group
+      case 5 ... 10, 12, 15, 20, 27, 28: .group
       default: fatalError("unknown WaterUI accessibility role: \(role)")
       }
       accessibilityTarget.setAccessibilityRole(accessibilityRole)

--- a/Sources/WaterUI/Components/Metadata/Visual/WuiOpacity.swift
+++ b/Sources/WaterUI/Components/Metadata/Visual/WuiOpacity.swift
@@ -50,7 +50,7 @@ final class WuiOpacity: PlatformView, WuiComponent {
 
   private func applyOpacity(_ alpha: Float) {
     precondition(
-      (0.0...1.0).contains(alpha),
+      (0.0 ... 1.0).contains(alpha),
       "Metadata<Opacity> value out of range: \(alpha)"
     )
 

--- a/Sources/WaterUI/Components/Typography/WuiTextBase.swift
+++ b/Sources/WaterUI/Components/Typography/WuiTextBase.swift
@@ -165,7 +165,7 @@ class WuiTextBase: PlatformView {
       _ = CTLineGetTypographicBounds(lastVisible, nil, &descent, &leading)
       let cappedHeight = ceil(frameHeight - origins[visibleCount - 1].y + descent + leading)
       var cappedWidth: CGFloat = 0
-      for line in lines[0..<visibleCount] {
+      for line in lines[0 ..< visibleCount] {
         let lineWidth = CGFloat(CTLineGetTypographicBounds(line, nil, nil, nil))
         cappedWidth = max(cappedWidth, ceil(lineWidth))
       }

--- a/Sources/WaterUI/Core/AnyView.swift
+++ b/Sources/WaterUI/Core/AnyView.swift
@@ -489,7 +489,6 @@ private func registerBuiltinComponentsIfNeeded() {
       // This is critical: WaterUI uses Rust layout engine, not AutoLayout
       inner.translatesAutoresizingMaskIntoConstraints = true
       addSubview(inner)
-
     }
 
     @available(*, unavailable)

--- a/Sources/WaterUI/Core/Views.swift
+++ b/Sources/WaterUI/Core/Views.swift
@@ -37,7 +37,7 @@ final class WuiAnyViews {
   }
 
   func takeRawView(at index: Int) -> OpaquePointer {
-    precondition((0..<count).contains(index), "WuiAnyViews index is out of bounds")
+    precondition((0 ..< count).contains(index), "WuiAnyViews index is out of bounds")
     return waterui_anyviews_get_view(inner, UInt(index))!
   }
 

--- a/Sources/WaterUI/StyledStr.swift
+++ b/Sources/WaterUI/StyledStr.swift
@@ -513,13 +513,13 @@ class WuiFont {
 
     switch raw {
     case ...(-0.8): return WuiFontWeight_Thin
-    case (-0.8)...(-0.6): return WuiFontWeight_UltraLight
-    case (-0.6)...(-0.4): return WuiFontWeight_Light
-    case (-0.4)...(0.0): return WuiFontWeight_Normal
-    case (0.0)...(0.23): return WuiFontWeight_Medium
-    case (0.23)...(0.3): return WuiFontWeight_SemiBold
-    case (0.3)...(0.5): return WuiFontWeight_Bold
-    case (0.5)...(0.8): return WuiFontWeight_UltraBold
+    case (-0.8) ... (-0.6): return WuiFontWeight_UltraLight
+    case (-0.6) ... (-0.4): return WuiFontWeight_Light
+    case (-0.4) ... (0.0): return WuiFontWeight_Normal
+    case (0.0) ... (0.23): return WuiFontWeight_Medium
+    case (0.23) ... (0.3): return WuiFontWeight_SemiBold
+    case (0.3) ... (0.5): return WuiFontWeight_Bold
+    case (0.5) ... (0.8): return WuiFontWeight_UltraBold
     default: return WuiFontWeight_Black
     }
   }
@@ -558,13 +558,13 @@ class WuiFont {
 
     switch raw {
     case ...(-0.8): return WuiFontWeight_Thin
-    case (-0.8)...(-0.6): return WuiFontWeight_UltraLight
-    case (-0.6)...(-0.4): return WuiFontWeight_Light
-    case (-0.4)...(0.0): return WuiFontWeight_Normal
-    case (0.0)...(0.23): return WuiFontWeight_Medium
-    case (0.23)...(0.3): return WuiFontWeight_SemiBold
-    case (0.3)...(0.5): return WuiFontWeight_Bold
-    case (0.5)...(0.8): return WuiFontWeight_UltraBold
+    case (-0.8) ... (-0.6): return WuiFontWeight_UltraLight
+    case (-0.6) ... (-0.4): return WuiFontWeight_Light
+    case (-0.4) ... (0.0): return WuiFontWeight_Normal
+    case (0.0) ... (0.23): return WuiFontWeight_Medium
+    case (0.23) ... (0.3): return WuiFontWeight_SemiBold
+    case (0.3) ... (0.5): return WuiFontWeight_Bold
+    case (0.5) ... (0.8): return WuiFontWeight_UltraBold
     default: return WuiFontWeight_Black
     }
   }


### PR DESCRIPTION
Fixes the two pre-existing reasons `dev` CI has been red since 2026-09-02 (water-rs/waterui#311): SwiftFormat 0.60's `spaceAroundOperators` on parenthesised range patterns (StyledStr.swift, Views.swift, WuiTable.swift) plus two blank-line rules (WuiFixedContainer.swift, AnyView.swift, WuiDatePicker.swift), and the `WuiList` key-window repaint closure that `-warnings-as-errors` rejects as non-Sendable — now `@Sendable`, hopping onto the main actor it is already delivered on.

Verified locally: `swiftformat . --lint` clean, `swift build -Xswiftc -warnings-as-errors` clean.