### PR TITLE
fix(toolbar): centre the tab control through NSToolbar.centeredItemIdentifiers

### DIFF
--- a/Sources/WaterUI/Components/Navigation/WuiWindowToolbar.swift
+++ b/Sources/WaterUI/Components/Navigation/WuiWindowToolbar.swift
@@ -145,6 +145,7 @@
       for (index, identifier) in currentIdentifiers.enumerated() {
         toolbar.insertItem(withItemIdentifier: identifier, at: index)
       }
+      toolbar.centeredItemIdentifiers = tabsView == nil ? [] : [Self.tabsIdentifier]
       window?.title = content.title ?? window?.title ?? ""
     }
 
@@ -170,10 +171,6 @@
       if content.trailing != nil { identifiers.append(Self.trailingIdentifier) }
       if content.search != nil { identifiers.append(Self.searchIdentifier) }
       return identifiers
-    }
-
-    func toolbarCenteredItemIdentifiers(_ toolbar: NSToolbar) -> Set<NSToolbarItem.Identifier> {
-      tabsView == nil ? [] : [Self.tabsIdentifier]
     }
 
     // MARK: - NSToolbarDelegate


### PR DESCRIPTION
The tab control was meant to sit in the toolbar's centre slot, but the centring was written as `toolbarCenteredItemIdentifiers(_:)` under the NSToolbarDelegate mark — a method NSToolbar never calls. `rebuild()` now sets `toolbar.centeredItemIdentifiers` next to the item list and the dead method is gone. Pre-existing; surfaced by periphery (water-rs/waterui#311).

Fixes water-rs/waterui#325