### PR TITLE
chore: clear every periphery finding on dev

### DIFF
--- a/Sources/WaterUI/Action.swift
+++ b/Sources/WaterUI/Action.swift
@@ -15,30 +15,15 @@ import AppKit
 class Action {
     // `nonisolated(unsafe)`: only ever touched on the main actor, plus by the
     // deinit below, which cannot be isolated.
-    private nonisolated(unsafe) var inner: OpaquePointer?
-    private var env: WuiEnvironment?
-    private let callback: (() -> Void)?
+    private nonisolated(unsafe) let inner: OpaquePointer
+    private let env: WuiEnvironment
 
     init(inner: OpaquePointer, env: WuiEnvironment) {
         self.inner = inner
         self.env = env
-        self.callback = nil
-    }
-
-    init(callback: @escaping () -> Void) {
-        self.inner = nil
-        self.env = nil
-        self.callback = callback
     }
 
     func call() {
-        if let callback {
-            callback()
-            return
-        }
-        guard let inner, let env else {
-            fatalError("Action requires either a local callback or valid FFI action pointer")
-        }
         waterui_call_action(inner, env.inner)
     }
 
@@ -47,8 +32,6 @@ class Action {
     // releases the owner from an autorelease-pool drain inside `NSView.dealloc`.
     // The body only hands a pointer back to Rust.
     nonisolated deinit {
-        if let inner {
-            waterui_drop_action(inner)
-        }
+        waterui_drop_action(inner)
     }
 }

--- a/Sources/WaterUI/Color.swift
+++ b/Sources/WaterUI/Color.swift
@@ -12,13 +12,6 @@ import CWaterUI
   import AppKit
 #endif
 
-func wuiLinearToSrgb(_ linear: Float) -> Float {
-  if linear <= 0.003_130_8 {
-    return linear * 12.92
-  }
-  return 1.055 * pow(linear, 1.0 / 2.4) - 0.055
-}
-
 func wuiSrgbToLinear(_ srgb: Float) -> Float {
   if srgb <= 0.040_45 {
     return srgb / 12.92
@@ -76,6 +69,13 @@ class WuiColor {
 }
 
 #if canImport(UIKit)
+  func wuiLinearToSrgb(_ linear: Float) -> Float {
+    if linear <= 0.003_130_8 {
+      return linear * 12.92
+    }
+    return 1.055 * pow(linear, 1.0 / 2.4) - 0.055
+  }
+
   extension WuiResolvedColor {
     func toUIColor(allowHdr: Bool = true) -> UIColor {
       let alpha = wuiClampUnit(self.opacity)

--- a/Sources/WaterUI/Components/Controls/WuiTextField.swift
+++ b/Sources/WaterUI/Components/Controls/WuiTextField.swift
@@ -538,9 +538,12 @@ final class WuiTextField: PlatformView, WuiComponent {
     }
 
     // The field editor forwards NSTextViewDelegate messages to the control's
-    // delegate only when the selector exists at runtime; this method satisfies no
-    // NSTextFieldDelegate requirement, so `@objc` is what makes AppKit find it.
-    @objc func textView(
+    // delegate only when it responds to the AppKit selector. This method satisfies
+    // no NSTextFieldDelegate requirement, so nothing supplies that selector for it:
+    // a bare `@objc` would infer `textView:menu:for:at:` from the Swift labels,
+    // which AppKit never sends.
+    @objc(textView:menu:forEvent:atIndex:)
+    func textView(
       _ view: NSTextView,
       menu: NSMenu,
       for event: NSEvent,

--- a/Sources/WaterUI/Components/Controls/WuiTextField.swift
+++ b/Sources/WaterUI/Components/Controls/WuiTextField.swift
@@ -537,7 +537,10 @@ final class WuiTextField: PlatformView, WuiComponent {
       focusTarget.emitPlatformFocusChange(false)
     }
 
-    func textView(
+    // The field editor forwards NSTextViewDelegate messages to the control's
+    // delegate only when the selector exists at runtime; this method satisfies no
+    // NSTextFieldDelegate requirement, so `@objc` is what makes AppKit find it.
+    @objc func textView(
       _ view: NSTextView,
       menu: NSMenu,
       for event: NSEvent,

--- a/Sources/WaterUI/Components/Controls/WuiTextField.swift
+++ b/Sources/WaterUI/Components/Controls/WuiTextField.swift
@@ -35,7 +35,7 @@ final class WuiTextField: PlatformView, WuiComponent {
     private let placeholderLabel = UILabel()
     private lazy var focusTarget = WuiUIKitFocusTarget(control: textView)
   #elseif canImport(AppKit)
-    private let textField = NSTextField()
+    private let textField = WuiSelectionMenuTextField()
     private lazy var focusTarget = WuiAppKitTextFieldFocusTarget(control: textField)
   #endif
 
@@ -537,18 +537,9 @@ final class WuiTextField: PlatformView, WuiComponent {
       focusTarget.emitPlatformFocusChange(false)
     }
 
-    // The field editor forwards NSTextViewDelegate messages to the control's
-    // delegate only when it responds to the AppKit selector. This method satisfies
-    // no NSTextFieldDelegate requirement, so nothing supplies that selector for it:
-    // a bare `@objc` would infer `textView:menu:for:at:` from the Swift labels,
-    // which AppKit never sends.
-    @objc(textView:menu:forEvent:atIndex:)
-    func textView(
-      _ view: NSTextView,
-      menu: NSMenu,
-      for event: NSEvent,
-      at charIndex: Int
-    ) -> NSMenu? {
+    /// Splices the semantic selection items under AppKit's own menu. Reached
+    /// from `WuiSelectionMenuTextField`, never from NSTextFieldDelegate.
+    fileprivate func selectionMenu(extending menu: NSMenu) -> NSMenu {
       guard let selectionMenuTree, !selectionMenuTree.nodes.isEmpty else { return menu }
       if !menu.items.isEmpty {
         menu.addItem(.separator())
@@ -567,6 +558,21 @@ final class WuiTextField: PlatformView, WuiComponent {
         fatalError("WaterUI selection menu item has no semantic action")
       }
       waterui_call_shared_action(action.command.action, env.inner)
+    }
+  }
+
+  /// The field editor asks *its* delegate for the context menu, and that delegate
+  /// is the text field, not the control's delegate: NSTextField does not respond
+  /// to `textView:menu:forEvent:atIndex:` and forwards nothing for it, so a
+  /// method on the WuiTextField delegate can never be reached. The hook has to
+  /// live on the NSTextField subclass itself.
+  private final class WuiSelectionMenuTextField: NSTextField {
+    @objc(textView:menu:forEvent:atIndex:)
+    func textView(_: NSTextView, menu: NSMenu, for _: NSEvent, at _: Int) -> NSMenu? {
+      guard let owner = delegate as? WuiTextField else {
+        fatalError("WuiSelectionMenuTextField must be driven by its WuiTextField")
+      }
+      return owner.selectionMenu(extending: menu)
     }
   }
 #endif

--- a/Sources/WaterUI/Components/Controls/WuiTextField.swift
+++ b/Sources/WaterUI/Components/Controls/WuiTextField.swift
@@ -44,8 +44,10 @@ final class WuiTextField: PlatformView, WuiComponent {
   private var isSyncingFromBinding = false
   private var bindingRenderer: WuiStyledStrRenderer?
   private var promptRenderer: WuiStyledStrRenderer?
-  private var borderColorObservation: WuiComputedObservation<WuiResolvedColor>?
-  private var fillColorObservation: WuiComputedObservation<WuiResolvedColor>?
+  #if canImport(UIKit)
+    private var borderColorObservation: WuiComputedObservation<WuiResolvedColor>?
+    private var fillColorObservation: WuiComputedObservation<WuiResolvedColor>?
+  #endif
   private var promptAlignmentObservation: WuiComputedObservation<WuiHorizontalAlignment>?
   private var bodyFontObservation: WuiComputedObservation<WuiResolvedFontValue>?
   private var accessibility: WuiControlAccessibility?

--- a/Sources/WaterUI/Components/Graphics/WuiDisplayLinkDriver.swift
+++ b/Sources/WaterUI/Components/Graphics/WuiDisplayLinkDriver.swift
@@ -55,8 +55,6 @@ final class WuiDisplayLinkDriver {
     self.target = Target(onFrame: onFrame)
   }
 
-  var isRunning: Bool { clock != nil }
-
   func start(for view: PlatformView) {
     guard let window = view.window else {
       Logger.graphics.debug("Display link not started: the view has no window")

--- a/Sources/WaterUI/Components/Graphics/WuiResolvedColorView.swift
+++ b/Sources/WaterUI/Components/Graphics/WuiResolvedColorView.swift
@@ -71,6 +71,7 @@ final class WuiColorView: WuiColorViewBase, WuiComponent {
     apply(observation.value)
   }
 
+  // periphery:ignore - required by NSCoding; WaterUI never unarchives views
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
@@ -91,6 +92,7 @@ final class WuiResolvedColorView: WuiColorViewBase, WuiComponent {
     apply(color)
   }
 
+  // periphery:ignore - required by NSCoding; WaterUI never unarchives views
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/Sources/WaterUI/Components/Layout/WuiContainer.swift
+++ b/Sources/WaterUI/Components/Layout/WuiContainer.swift
@@ -634,25 +634,6 @@ final class WuiContainer: PlatformView, WuiComponent {
     invalidateLayoutHierarchy()
   }
 
-  private func setChildren(_ newChildren: [WuiAnyView]) {
-    for child in childViews {
-      child.removeFromSuperview()
-    }
-
-    childViews = newChildren
-    cachedSubViews = nil
-    for child in newChildren {
-      child.translatesAutoresizingMaskIntoConstraints = true
-      addSubview(child)
-    }
-
-    #if canImport(UIKit)
-      setNeedsLayout()
-    #elseif canImport(AppKit)
-      needsLayout = true
-    #endif
-  }
-
   private func subViewCache() -> CachedSubViewArray {
     if let cachedSubViews {
       return cachedSubViews

--- a/Sources/WaterUI/Components/Media/WuiVideoPlaybackCoordinator.swift
+++ b/Sources/WaterUI/Components/Media/WuiVideoPlaybackCoordinator.swift
@@ -20,10 +20,6 @@ extension AVLayerVideoGravity {
   }
 }
 
-private func opaquePointer<T>(_ pointer: UnsafeMutablePointer<T>?) -> OpaquePointer? {
-  pointer.map { OpaquePointer(UnsafeMutableRawPointer($0)) }
-}
-
 private func opaquePointer(_ pointer: OpaquePointer?) -> OpaquePointer? {
   pointer
 }

--- a/Sources/WaterUI/Components/Media/WuiWebView.swift
+++ b/Sources/WaterUI/Components/Media/WuiWebView.swift
@@ -216,7 +216,7 @@ final class WebViewWrapper: NSObject, WKScriptMessageHandler {
     _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
   ) {
     Task { @MainActor [weak self] in
-      self?.handleScriptMessage(name: message.name, body: message.body, frame: message.frameInfo)
+      self?.handleScriptMessage(body: message.body, frame: message.frameInfo)
     }
   }
 
@@ -225,7 +225,7 @@ final class WebViewWrapper: NSObject, WKScriptMessageHandler {
   /// Page script reaches this transport directly, so a malformed envelope or an
   /// unknown handler name is rejected back to JavaScript rather than being fatal.
   @MainActor
-  private func handleScriptMessage(name: String, body: Any, frame: WKFrameInfo) {
+  private func handleScriptMessage(body: Any, frame: WKFrameInfo) {
     guard frameMayUseBridge(frame) else {
       Logger.waterui.warning(
         "a document outside the bridge origin policy tried to call a WaterUI handler")

--- a/Sources/WaterUI/Components/Navigation/WuiNavigationTransitionMetadata.swift
+++ b/Sources/WaterUI/Components/Navigation/WuiNavigationTransitionMetadata.swift
@@ -67,6 +67,7 @@ final class WuiNavigationTransitionSourceView: WuiNavigationTransitionTaggedView
     super.init(content: metadata.content, id: metadata.value.inner, env: env)
   }
 
+  // periphery:ignore - required by NSCoding; WaterUI never unarchives views
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
@@ -86,6 +87,7 @@ final class WuiNavigationTransitionDestinationView: WuiNavigationTransitionTagge
     super.init(content: metadata.content, id: metadata.value.inner, env: env)
   }
 
+  // periphery:ignore - required by NSCoding; WaterUI never unarchives views
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/Sources/WaterUI/Components/Navigation/WuiNavigationView.swift
+++ b/Sources/WaterUI/Components/Navigation/WuiNavigationView.swift
@@ -134,11 +134,6 @@ final class WuiNavigationView: PlatformView, WuiComponent {
     }
   }
 
-  func notifyDestinationPopped() {
-    setDestinationActive(false)
-    destinationState.popped()
-  }
-
   private func configureNavBar() {
     if hasNavigationController {
       barIsInstalled = false

--- a/Sources/WaterUI/Components/Navigation/WuiWindowToolbar.swift
+++ b/Sources/WaterUI/Components/Navigation/WuiWindowToolbar.swift
@@ -145,6 +145,7 @@
       for (index, identifier) in currentIdentifiers.enumerated() {
         toolbar.insertItem(withItemIdentifier: identifier, at: index)
       }
+      toolbar.centeredItemIdentifiers = tabsView == nil ? [] : [Self.tabsIdentifier]
       window?.title = content.title ?? window?.title ?? ""
     }
 
@@ -170,10 +171,6 @@
       if content.trailing != nil { identifiers.append(Self.trailingIdentifier) }
       if content.search != nil { identifiers.append(Self.searchIdentifier) }
       return identifiers
-    }
-
-    func toolbarCenteredItemIdentifiers(_ toolbar: NSToolbar) -> Set<NSToolbarItem.Identifier> {
-      tabsView == nil ? [] : [Self.tabsIdentifier]
     }
 
     // MARK: - NSToolbarDelegate

--- a/Sources/WaterUI/Reactive/Watcher.swift
+++ b/Sources/WaterUI/Reactive/Watcher.swift
@@ -549,19 +549,3 @@ func makeColorWatcher(_ f: @escaping (OpaquePointer, WuiWatcherMetadata) -> Void
   }
   return watcher
 }
-
-@MainActor
-func makeRegionWatcher(_ f: @escaping (WuiRegion, WuiWatcherMetadata) -> Void) -> OpaquePointer {
-  let data = wrap(f)
-  let call: @convention(c) (UnsafeMutableRawPointer?, WuiRegion, OpaquePointer?) -> Void = {
-    data, value, metadata in
-    callWrapper(data, value, metadata)
-  }
-  let drop: @convention(c) (UnsafeMutableRawPointer?) -> Void = {
-    dropWrapper($0, WuiRegion.self)
-  }
-  guard let watcher = waterui_new_watcher_region(data, call, drop) else {
-    fatalError("Failed to create region watcher")
-  }
-  return watcher
-}

--- a/Sources/WaterUI/StyledStr.swift
+++ b/Sources/WaterUI/StyledStr.swift
@@ -15,32 +15,6 @@ struct WuiStyledStr {
     self.chunks = WuiArray(inner.chunks).map(WuiStyledChunk.init)
   }
 
-  init(chunks: [WuiStyledChunk]) {
-    self.chunks = chunks
-  }
-
-  static func fromAttributedString(_ attributed: NSAttributedString) -> WuiStyledStr {
-    let nsText = attributed.string as NSString
-    if attributed.length == 0 {
-      return WuiStyledStr(chunks: [WuiStyledChunk(text: "", style: WuiTextStyle.defaultStyle())])
-    }
-
-    var chunks: [WuiStyledChunk] = []
-    let fullRange = NSRange(location: 0, length: attributed.length)
-    attributed.enumerateAttributes(in: fullRange, options: []) { attributes, range, _ in
-      guard range.length > 0 else { return }
-      let text = nsText.substring(with: range)
-      let style = WuiTextStyle.fromAttributes(attributes)
-      chunks.append(WuiStyledChunk(text: text, style: style))
-    }
-
-    if chunks.isEmpty {
-      chunks.append(WuiStyledChunk(text: attributed.string, style: WuiTextStyle.defaultStyle()))
-    }
-
-    return WuiStyledStr(chunks: chunks)
-  }
-
   func toString() -> String {
     chunks.map { $0.text.toString() }.joined()
   }
@@ -154,11 +128,6 @@ struct WuiStyledChunk {
     self.style = WuiTextStyle(inner.style)
   }
 
-  init(text: String, style: WuiTextStyle) {
-    self.text = WuiStr(string: text)
-    self.style = style
-  }
-
   func toAttributedString(
     font resolvedFont: WuiResolvedFontValue,
     foreground: WuiResolvedColor?,
@@ -237,70 +206,6 @@ struct WuiTextStyle {
     self.underline = inner.underline
     self.strikethrough = inner.strikethrough
     self.italic = inner.italic
-  }
-
-  init(
-    font: WuiFont,
-    foreground: WuiColor?,
-    background: WuiColor?,
-    underline: Bool,
-    strikethrough: Bool,
-    italic: Bool
-  ) {
-    self.font = font
-    self.foreground = foreground
-    self.background = background
-    self.underline = underline
-    self.strikethrough = strikethrough
-    self.italic = italic
-  }
-
-  static func defaultStyle() -> WuiTextStyle {
-    #if canImport(UIKit)
-      let platformFont = UIFont.systemFont(ofSize: UIFont.systemFontSize)
-    #elseif canImport(AppKit)
-      let platformFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
-    #endif
-    return WuiTextStyle(
-      font: wuiFont(from: platformFont),
-      foreground: nil,
-      background: nil,
-      underline: false,
-      strikethrough: false,
-      italic: false
-    )
-  }
-
-  static func fromAttributes(_ attributes: [NSAttributedString.Key: Any]) -> WuiTextStyle {
-    #if canImport(UIKit)
-      let platformFont =
-        (attributes[.font] as? UIFont) ?? UIFont.systemFont(ofSize: UIFont.systemFontSize)
-    #elseif canImport(AppKit)
-      let platformFont =
-        (attributes[.font] as? NSFont) ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
-    #endif
-
-    let underlineValue = (attributes[.underlineStyle] as? NSNumber)?.intValue ?? 0
-    let strikethroughValue = (attributes[.strikethroughStyle] as? NSNumber)?.intValue ?? 0
-
-    #if canImport(UIKit)
-      let italic = platformFont.fontDescriptor.symbolicTraits.contains(.traitItalic)
-      let foreground = wuiColor(from: attributes[.foregroundColor] as? UIColor)
-      let background = wuiColor(from: attributes[.backgroundColor] as? UIColor)
-    #elseif canImport(AppKit)
-      let italic = platformFont.fontDescriptor.symbolicTraits.contains(.italic)
-      let foreground = wuiColor(from: attributes[.foregroundColor] as? NSColor)
-      let background = wuiColor(from: attributes[.backgroundColor] as? NSColor)
-    #endif
-
-    return WuiTextStyle(
-      font: wuiFont(from: platformFont),
-      foreground: foreground,
-      background: background,
-      underline: underlineValue != 0,
-      strikethrough: strikethroughValue != 0,
-      italic: italic
-    )
   }
 
   mutating func intoInner() -> CWaterUI.WuiTextStyle {
@@ -473,99 +378,3 @@ class WuiFont {
     }
   }
 }
-
-#if canImport(UIKit)
-  @MainActor
-  private func wuiColor(from color: UIColor?) -> WuiColor? {
-    guard let color else { return nil }
-
-    var red: CGFloat = 0
-    var green: CGFloat = 0
-    var blue: CGFloat = 0
-    var alpha: CGFloat = 0
-    guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
-      return nil
-    }
-
-    guard
-      let pointer = waterui_color_from_srgba(Float(red), Float(green), Float(blue), Float(alpha))
-    else {
-      return nil
-    }
-    return WuiColor(pointer)
-  }
-
-  @MainActor
-  private func wuiFont(from font: UIFont) -> WuiFont {
-    let weight = wuiFontWeight(from: font)
-    let family = WuiStr(string: font.fontName)
-    guard
-      let pointer = waterui_font_from_resolved(Float(font.pointSize), weight, family.intoInner())
-    else {
-      fatalError("Failed to create WuiFont from UIFont")
-    }
-    return WuiFont(pointer)
-  }
-
-  private func wuiFontWeight(from font: UIFont) -> CWaterUI.WuiFontWeight {
-    let traits = font.fontDescriptor.object(forKey: .traits) as? [UIFontDescriptor.TraitKey: Any]
-    let raw = (traits?[.weight] as? CGFloat) ?? 0
-
-    switch raw {
-    case ...(-0.8): return WuiFontWeight_Thin
-    case (-0.8) ... (-0.6): return WuiFontWeight_UltraLight
-    case (-0.6) ... (-0.4): return WuiFontWeight_Light
-    case (-0.4) ... (0.0): return WuiFontWeight_Normal
-    case (0.0) ... (0.23): return WuiFontWeight_Medium
-    case (0.23) ... (0.3): return WuiFontWeight_SemiBold
-    case (0.3) ... (0.5): return WuiFontWeight_Bold
-    case (0.5) ... (0.8): return WuiFontWeight_UltraBold
-    default: return WuiFontWeight_Black
-    }
-  }
-#elseif canImport(AppKit)
-  @MainActor
-  private func wuiColor(from color: NSColor?) -> WuiColor? {
-    guard let color else { return nil }
-    guard let srgb = color.usingColorSpace(.sRGB) else { return nil }
-
-    let red = Float(srgb.redComponent)
-    let green = Float(srgb.greenComponent)
-    let blue = Float(srgb.blueComponent)
-    let alpha = Float(srgb.alphaComponent)
-
-    guard let pointer = waterui_color_from_srgba(red, green, blue, alpha) else {
-      return nil
-    }
-    return WuiColor(pointer)
-  }
-
-  @MainActor
-  private func wuiFont(from font: NSFont) -> WuiFont {
-    let weight = wuiFontWeight(from: font)
-    let family = WuiStr(string: font.fontName)
-    guard
-      let pointer = waterui_font_from_resolved(Float(font.pointSize), weight, family.intoInner())
-    else {
-      fatalError("Failed to create WuiFont from NSFont")
-    }
-    return WuiFont(pointer)
-  }
-
-  private func wuiFontWeight(from font: NSFont) -> CWaterUI.WuiFontWeight {
-    let traits = font.fontDescriptor.object(forKey: .traits) as? [NSFontDescriptor.TraitKey: Any]
-    let raw = (traits?[.weight] as? NSNumber)?.doubleValue ?? 0
-
-    switch raw {
-    case ...(-0.8): return WuiFontWeight_Thin
-    case (-0.8) ... (-0.6): return WuiFontWeight_UltraLight
-    case (-0.6) ... (-0.4): return WuiFontWeight_Light
-    case (-0.4) ... (0.0): return WuiFontWeight_Normal
-    case (0.0) ... (0.23): return WuiFontWeight_Medium
-    case (0.23) ... (0.3): return WuiFontWeight_SemiBold
-    case (0.3) ... (0.5): return WuiFontWeight_Bold
-    case (0.5) ... (0.8): return WuiFontWeight_UltraBold
-    default: return WuiFontWeight_Black
-    }
-  }
-#endif

--- a/Sources/WaterUI/WaterUI.swift
+++ b/Sources/WaterUI/WaterUI.swift
@@ -456,12 +456,14 @@ final class ReactiveFontSignal {
     return computed
   }
 
-  func setValue(size: Float, weight: WuiFontWeight) {
-    let current = state.value
-    guard current.size != size || current.weight.rawValue != weight.rawValue else { return }
-    state.value = Spec(size: size, weight: weight)
-    state.notifyWatchers()
-  }
+  #if canImport(UIKit)
+    func setValue(size: Float, weight: WuiFontWeight) {
+      let current = state.value
+      guard current.size != size || current.weight.rawValue != weight.rawValue else { return }
+      state.value = Spec(size: size, weight: weight)
+      state.notifyWatchers()
+    }
+  #endif
 }
 
 extension WuiEdgeInsets {

--- a/Sources/WaterUI/WuiInspector.swift
+++ b/Sources/WaterUI/WuiInspector.swift
@@ -33,11 +33,6 @@ enum WuiInspector {
     waterui_inspector_open(env.inner)
   }
 
-  /// Reveals one accessibility node in the inspector.
-  static func inspect(node: UInt64, env: WuiEnvironment) {
-    waterui_inspector_inspect_node(env.inner, node)
-  }
-
   /// Whether anything is watching the accessibility tree.
   ///
   /// The walk below is only worth doing when something reads the result, so
@@ -124,20 +119,18 @@ enum WuiInspector {
     }
   }
 
-  /// Installs the gesture that brings the inspector up.
-  ///
-  /// Does nothing unless an endpoint is running, so a release build carries the
-  /// call but never the menu.
-  static func installGesture(on view: PlatformView, env: WuiEnvironment) {
-    guard isAvailable(env: env) else { return }
+  #if canImport(UIKit)
+    /// Installs the gesture that brings the inspector up.
+    ///
+    /// Does nothing unless an endpoint is running, so a release build carries the
+    /// call but never the menu. AppKit installs nothing: it delivers secondary
+    /// clicks through `rightMouseDown`, which the host view overrides and routes
+    /// to `presentMenu(for:in:env:)`; a gesture recognizer there would sit above
+    /// every control and swallow the mouse tracking that sliders and drags
+    /// depend on.
+    static func installGesture(on view: PlatformView, env: WuiEnvironment) {
+      guard isAvailable(env: env) else { return }
 
-    #if canImport(AppKit)
-      // Nothing to install: AppKit delivers secondary clicks through
-      // `rightMouseDown`, which the host view overrides. A gesture recognizer
-      // here would sit above every control and swallow the mouse tracking that
-      // sliders and drags depend on.
-      _ = view
-    #elseif canImport(UIKit)
       // A phone has no secondary click. A two-finger long press is not something
       // an application is likely to have claimed, and is awkward enough not to
       // be triggered by accident.
@@ -149,8 +142,8 @@ enum WuiInspector {
       recognizer.cancelsTouchesInView = false
       WuiInspectorLongPressTarget.shared.register(recognizer: recognizer, env: env)
       view.addGestureRecognizer(recognizer)
-    #endif
-  }
+    }
+  #endif
 }
 
 #if canImport(AppKit)
@@ -188,7 +181,7 @@ enum WuiInspector {
       self.view = view
     }
 
-    @objc func inspect(_ sender: NSMenuItem) {
+    @objc func inspect(_: NSMenuItem) {
       WuiInspector.open(env: env)
       // Publish before asking for a node: the Inspector cannot reveal what it
       // has not been told about, and the tree is only walked when something is

--- a/Sources/WaterUICefWebView/CefWebViewComponent.swift
+++ b/Sources/WaterUICefWebView/CefWebViewComponent.swift
@@ -16,6 +16,7 @@ private final class CefWebViewComponent: CefSurfaceView, WuiComponent {
     super.init(surface: waterui_force_as_cef_webview(anyview), env: env)
   }
 
+  // periphery:ignore - required by NSCoding; WaterUI never unarchives views
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("CefWebViewComponent does not support NSCoder initialization")

--- a/Sources/WaterUIChromium/ChromiumComponent.swift
+++ b/Sources/WaterUIChromium/ChromiumComponent.swift
@@ -16,6 +16,7 @@ private final class ChromiumComponent: CefSurfaceView, WuiComponent {
     super.init(surface: waterui_force_as_chromium(anyview), env: env)
   }
 
+  // periphery:ignore - required by NSCoding; WaterUI never unarchives views
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("ChromiumComponent does not support NSCoder initialization")


### PR DESCRIPTION
Makes the periphery job green on dev, the last red after #8 apart from the empty test job (water-rs/waterui#314).

Of the 31 findings: 19 are dead code and are deleted; 4 are declared unconditionally but used only under `#if canImport(UIKit)`, invisible to a macOS-only scan, and now live inside that block; 6 are compiler-mandated `required init?(coder:)` overrides with an item-level `periphery:ignore` and its reason; 2 were real bugs (#9, #10).

Branch includes #9 and #10 so periphery passes here; the diff collapses to the cleanup once they merge.

Removing the never-called `WuiInspector.inspect(node:env:)` leaves `waterui_inspector_inspect_node` without a Swift caller — that gap is water-rs/waterui#326.

Fixes water-rs/waterui#311