### PR TITLE
ci: drop the test job until the package has a test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,6 @@ jobs:
       - name: Build release
         run: swift build --configuration release -Xswiftc -warnings-as-errors
 
-  test:
-    name: test
-    runs-on: macos-26
-    steps:
-      - uses: actions/checkout@v4
-      - name: Sync WaterUI header
-        run: ./.github/scripts/setup-waterui.sh
-      - name: Run tests
-        run: swift test -Xswiftc -warnings-as-errors
-
   periphery:
     name: periphery
     runs-on: macos-26
@@ -79,7 +69,7 @@ jobs:
   notify-waterui:
     name: notify-waterui
     runs-on: ubuntu-latest
-    needs: [lint, build-debug, build-release, test, periphery]
+    needs: [lint, build-debug, build-release, periphery]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Send repository_dispatch to waterui


### PR DESCRIPTION
The `test` job has been red on every push since the only test target was deleted in July (`swift test` → "no tests found; create a target in the Tests directory"), the last red on `dev` after #11. Decided 2026-09-05: remove the job rather than keep a check that can only fail; it comes back with the first real XCTest target.

Fixes water-rs/waterui#314