### PR TITLE
fix: restore makeRegionWatcher and compile every CLI Swift shape in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,26 +31,36 @@ jobs:
       - name: ast-grep
         run: sg scan Sources Tests --inline-rules "$(cat .ci/sg/swift.yml)" --report-style short
 
-  build-debug:
-    name: build-debug
+  build:
+    name: build (${{ matrix.configuration }}, ${{ matrix.shape.name }})
     runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [debug, release]
+        # Every Swift compilation condition the water CLI can hand this
+        # package (`apple_swift_conditions` in waterui's cli/src/apple/platform.rs)
+        # is a shape of its own. `WATERUI_MAP` adds the map component;
+        # `WATERUI_NO_GPU` removes the GPU surface. Neither is compiled by the
+        # default shape, and a symbol used only behind one of them once shipped
+        # deleted (waterui#343).
+        shape:
+          - { name: default, flags: "" }
+          - { name: map, flags: "-Xswiftc -DWATERUI_MAP" }
+          - { name: no-gpu, flags: "-Xswiftc -DWATERUI_NO_GPU" }
     steps:
       - uses: actions/checkout@v4
       - name: Sync WaterUI header
         run: ./.github/scripts/setup-waterui.sh
-      - name: Build debug
-        run: swift build --configuration debug -Xswiftc -warnings-as-errors
+      - name: Build
+        run: >-
+          swift build --configuration ${{ matrix.configuration }}
+          -Xswiftc -warnings-as-errors ${{ matrix.shape.flags }}
 
-  build-release:
-    name: build-release
-    runs-on: macos-26
-    steps:
-      - uses: actions/checkout@v4
-      - name: Sync WaterUI header
-        run: ./.github/scripts/setup-waterui.sh
-      - name: Build release
-        run: swift build --configuration release -Xswiftc -warnings-as-errors
-
+  # Scans the largest shape (`.periphery.yml` passes `-DWATERUI_MAP`), so code
+  # that only the map component reaches counts as used. `WATERUI_NO_GPU` only
+  # swaps implementations and adds no symbols of its own, so the default shape
+  # plus the map shape is the whole package.
   periphery:
     name: periphery
     runs-on: macos-26
@@ -69,7 +79,7 @@ jobs:
   notify-waterui:
     name: notify-waterui
     runs-on: ubuntu-latest
-    needs: [lint, build-debug, build-release, periphery]
+    needs: [lint, build, periphery]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Send repository_dispatch to waterui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,31 +31,40 @@ jobs:
       - name: ast-grep
         run: sg scan Sources Tests --inline-rules "$(cat .ci/sg/swift.yml)" --report-style short
 
+  # Every Swift compilation condition the water CLI can hand this package
+  # (`apple_swift_conditions` in waterui's cli/src/apple/platform.rs) is built:
+  # `WATERUI_MAP` adds the map component; `WATERUI_NO_GPU` removes the GPU
+  # surface. Neither is compiled by the default shape, and a symbol used only
+  # behind one of them once shipped deleted (waterui#343).
+  #
+  # The three shapes are steps of one job per configuration, not a matrix
+  # axis: they share the checkout, the header sync and the build directory,
+  # and macOS runners are what the org's concurrent-job cap runs out of, so
+  # one job that builds three shapes in a row gets through the queue where
+  # three jobs wait on three runners.
   build:
-    name: build (${{ matrix.configuration }}, ${{ matrix.shape.name }})
+    name: build (${{ matrix.configuration }})
     runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
         configuration: [debug, release]
-        # Every Swift compilation condition the water CLI can hand this
-        # package (`apple_swift_conditions` in waterui's cli/src/apple/platform.rs)
-        # is a shape of its own. `WATERUI_MAP` adds the map component;
-        # `WATERUI_NO_GPU` removes the GPU surface. Neither is compiled by the
-        # default shape, and a symbol used only behind one of them once shipped
-        # deleted (waterui#343).
-        shape:
-          - { name: default, flags: "" }
-          - { name: map, flags: "-Xswiftc -DWATERUI_MAP" }
-          - { name: no-gpu, flags: "-Xswiftc -DWATERUI_NO_GPU" }
     steps:
       - uses: actions/checkout@v4
       - name: Sync WaterUI header
         run: ./.github/scripts/setup-waterui.sh
-      - name: Build
+      - name: Build (default)
         run: >-
           swift build --configuration ${{ matrix.configuration }}
-          -Xswiftc -warnings-as-errors ${{ matrix.shape.flags }}
+          -Xswiftc -warnings-as-errors
+      - name: Build (map)
+        run: >-
+          swift build --configuration ${{ matrix.configuration }}
+          -Xswiftc -warnings-as-errors -Xswiftc -DWATERUI_MAP
+      - name: Build (no-gpu)
+        run: >-
+          swift build --configuration ${{ matrix.configuration }}
+          -Xswiftc -warnings-as-errors -Xswiftc -DWATERUI_NO_GPU
 
   # Scans the largest shape (`.periphery.yml` passes `-DWATERUI_MAP`), so code
   # that only the map component reaches counts as used. `WATERUI_NO_GPU` only

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -13,3 +13,8 @@ index_exclude:
   - .build/**
   - Tests/**
   - waterui/**
+# The largest shape: the map component only exists behind this condition, and
+# without it every symbol it alone reaches is reported unused (waterui#343).
+build_arguments:
+  - -Xswiftc
+  - -DWATERUI_MAP

--- a/Sources/WaterUI/Reactive/Watcher.swift
+++ b/Sources/WaterUI/Reactive/Watcher.swift
@@ -165,6 +165,24 @@ func makeDoubleWatcher(_ f: @escaping (Double, WuiWatcherMetadata) -> Void) -> O
   return watcher
 }
 
+/// Region watcher for the map component. Its only caller is compiled under
+/// `WATERUI_MAP`, so it is unused in the default shape by construction.
+@MainActor
+func makeRegionWatcher(_ f: @escaping (WuiRegion, WuiWatcherMetadata) -> Void) -> OpaquePointer {
+  let data = wrap(f)
+  let call: @convention(c) (UnsafeMutableRawPointer?, WuiRegion, OpaquePointer?) -> Void = {
+    data, value, metadata in
+    callWrapper(data, value, metadata)
+  }
+  let drop: @convention(c) (UnsafeMutableRawPointer?) -> Void = {
+    dropWrapper($0, WuiRegion.self)
+  }
+  guard let watcher = waterui_new_watcher_region(data, call, drop) else {
+    fatalError("Failed to create region watcher")
+  }
+  return watcher
+}
+
 @MainActor
 func makeFloatWatcher(_ f: @escaping (Float, WuiWatcherMetadata) -> Void) -> OpaquePointer {
   let data = wrap(f)


### PR DESCRIPTION
#11 removed `makeRegionWatcher` on periphery's word. Its only caller is behind `#if WATERUI_MAP`, which the water CLI defines for apps that link the map component and which nothing in this repository's CI compiled, so `water run` on waterui's `examples/map` failed with `cannot find 'makeRegionWatcher' in scope` while CI was green. Regression from my own cleanup; details in water-rs/waterui#343.

- `makeRegionWatcher` restored in `Reactive/Watcher.swift`.
- `build-debug` / `build-release` become one `build` matrix over configuration × shape (`default`, `map`, `no-gpu`), so every condition `apple_swift_conditions` can emit is compiled in both configurations.
- Periphery scans the largest shape (`build_arguments: -Xswiftc -DWATERUI_MAP` in `.periphery.yml`); `WATERUI_NO_GPU` only swaps implementations and adds no symbols, so default + map is the whole package.

Verified locally: all three debug shapes build with `-warnings-as-errors`, `periphery scan --config .periphery.yml` reports no unused code, swiftformat and swiftlint are clean. No status check is required by name on `dev`, so the job rename is safe.

Fixes water-rs/waterui#343