### PR TITLE
fix(graphics): present filtered photos and survive a filter laid out empty

### DIFF
--- a/Sources/WaterUI/Components/Graphics/WuiGpuSurface.swift
+++ b/Sources/WaterUI/Components/Graphics/WuiGpuSurface.swift
@@ -64,6 +64,7 @@ private final class WuiGpuSurfaceRenderState {
   private var needsRender = true
   private(set) var hasRenderedFrame = false
   private var lastResolvedMeasurement: WuiViewDimensions
+  private var lastProposal: WuiProposalSize?
   private var deferredMeasurementInvalidation = false
   private let cachedPriority: Int32
   private var width: UInt32 = 0
@@ -328,6 +329,7 @@ private final class WuiGpuSurfaceRenderState {
   }
 
   func measure(_ proposal: WuiProposalSize) -> WuiViewDimensions {
+    lastProposal = proposal
     if !rendererSetupStarted || isSetupReady {
       let dimensions = WuiViewDimensions(
         waterui_gpu_surface_measure(gpuState, proposal.toCStruct()))
@@ -341,9 +343,32 @@ private final class WuiGpuSurfaceRenderState {
     return lastResolvedMeasurement
   }
 
+  /// Whether the host laid this surface out with a measurement the renderer
+  /// no longer gives.
+  ///
+  /// A `GpuView` whose content changes size — a photo whose first frame just
+  /// decoded — requests a redraw, which is the only signal it has; native
+  /// layout is on demand, so the surface asks the renderer again with the
+  /// proposal it was last measured with and reports a stale box to the host.
+  ///
+  /// Asked whenever the renderer can answer — before setup starts as well as
+  /// after it completes — and not only once the surface is attached: a
+  /// content-sized view that first measured empty was never given the bounds
+  /// that attaching requires, so gating this on setup would leave it empty
+  /// for good.
   func takeMeasurementInvalidation() -> Bool {
-    guard deferredMeasurementInvalidation else { return false }
-    deferredMeasurementInvalidation = false
+    if deferredMeasurementInvalidation {
+      guard isSetupReady else { return false }
+      deferredMeasurementInvalidation = false
+      return true
+    }
+    guard !rendererSetupStarted || isSetupReady, let proposal = lastProposal else {
+      return false
+    }
+    let dimensions = WuiViewDimensions(
+      waterui_gpu_surface_measure(gpuState, proposal.toCStruct()))
+    guard dimensions.cgSize != lastResolvedMeasurement.cgSize else { return false }
+    lastResolvedMeasurement = dimensions
     return true
   }
 
@@ -1149,15 +1174,11 @@ final class WuiGpuSurface: PlatformView, WuiComponent, WuiFirstPaintReadyPartici
 
   private func handleRedrawRequest() {
     completeSetupIfReady()
-    if renderState.isSetupReady && renderState.takeMeasurementInvalidation() {
-      invalidateIntrinsicContentSize()
-      #if canImport(UIKit)
-        setNeedsLayout()
-        superview?.setNeedsLayout()
-      #elseif canImport(AppKit)
-        needsLayout = true
-        superview?.needsLayout = true
-      #endif
+    if renderState.takeMeasurementInvalidation() {
+      // The whole ancestor chain, not just the parent: a stack that grew
+      // re-lays its own children inside the box its parent gave it, so only a
+      // root-to-leaf pass moves the siblings that follow this surface.
+      invalidateLayoutHierarchy()
     }
     if externalRenderingScopes.isActive {
       externalRenderingScopes.notifyRedraw()

--- a/Sources/WaterUI/Components/Graphics/WuiMetalViewCapture.swift
+++ b/Sources/WaterUI/Components/Graphics/WuiMetalViewCapture.swift
@@ -610,6 +610,24 @@ final class WuiMetalViewCapture: @unchecked Sendable {
       captureRenderer = renderer
     }
 
+    // `CARenderer` draws over whatever the destination already holds and never
+    // clears it, so a private texture — fresh or reused — carries uninitialised
+    // memory under the layer tree, which the composite then treats as opaque
+    // content. One empty pass on the same queue clears it ahead of the render;
+    // command buffers on one queue execute in commit order.
+    let clearDescriptor = MTLRenderPassDescriptor()
+    clearDescriptor.colorAttachments[0].texture = texture
+    clearDescriptor.colorAttachments[0].loadAction = .clear
+    clearDescriptor.colorAttachments[0].storeAction = .store
+    clearDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0, 0, 0, 0)
+    guard let clearBuffer = queue.makeCommandBuffer(),
+      let clearEncoder = clearBuffer.makeRenderCommandEncoder(descriptor: clearDescriptor)
+    else {
+      fatalError("Failed to encode the native capture clear pass")
+    }
+    clearEncoder.endEncoding()
+    clearBuffer.commit()
+
     renderer.layer = layer
     // The destination rectangle is in pixels; `withCaptureTransform` brings the
     // point-space layer tree into that same space.

--- a/Sources/WaterUI/Components/Metadata/Visual/WuiAppliedFilter.swift
+++ b/Sources/WaterUI/Components/Metadata/Visual/WuiAppliedFilter.swift
@@ -241,7 +241,10 @@ final class WuiAppliedFilter: PlatformView, WuiComponent, WuiFirstPaintReadyPart
   }
 
   private func initializeGpuIfNeeded() {
-    guard bounds.width > 0, bounds.height > 0 else { return }
+    guard bounds.width > 0, bounds.height > 0 else {
+      releasePresentation()
+      return
+    }
     #if canImport(UIKit)
       guard window != nil else { return }
     #elseif canImport(AppKit)
@@ -466,19 +469,32 @@ final class WuiAppliedFilter: PlatformView, WuiComponent, WuiFirstPaintReadyPart
 
   private func handleWindowChange() {
     if window == nil {
-      stopDisplayLink()
-      pendingDynamicRangeMode = nil
-      completeReady(false)
-      if renderInFlight {
-        detachAfterCapture = true
-      } else {
-        renderState.detachIfNeeded()
-      }
+      releasePresentation()
       return
     }
     detachAfterCapture = false
     initializeGpuIfNeeded()
     requestRenderIfNeeded()
+  }
+
+  /// Drops the attached output once the view can no longer present: it left
+  /// the window, or layout gave it zero bounds. The capture pipeline requires
+  /// non-zero content bounds, and a filter whose content measures empty (a
+  /// photo that has not decoded yet) is laid out at zero after being attached
+  /// at the size its host first offered, so an attached output over an empty
+  /// layout would capture nothing and trap. A capture in flight finishes and
+  /// detaches on completion; a later layout to a real size attaches again
+  /// through `initializeGpuIfNeeded`.
+  private func releasePresentation() {
+    stopDisplayLink()
+    needsRender = false
+    pendingDynamicRangeMode = nil
+    completeReady(false)
+    if renderInFlight {
+      detachAfterCapture = true
+    } else {
+      renderState.detachIfNeeded()
+    }
   }
 
   /// Positions the presentation layer. Its drawable size belongs to wgpu, which


### PR DESCRIPTION
Fixes water-rs/waterui#352. Apple half of water-rs/waterui#310 (the ffi half and the submodule bump are in the waterui PR).

Three pre-existing defects on the capture path, found while making a filtered `Photo` show up:

- **`WuiMetalViewCapture`**: `CARenderer` draws over whatever its destination already holds and never clears it, so the composite treated uninitialised texture memory under the layer tree as opaque content. One empty clear pass on the capture queue now precedes every native render.
- **`WuiGpuSurface`**: a surface whose content changes size after setup (a photo whose first frame decoded) requested a redraw that nobody turned into a layout, so it kept the 0x0 box it was first measured with and the views after it landed on top of it. The redraw handler re-measures with the last proposal and, on a change, invalidates the whole ancestor chain.
- **`WuiAppliedFilter`**: a filter attached at the size a `Dynamic` host first offered, then laid out to zero around a photo that had not decoded yet, kept its attached output and asked for a frame, and the capture pipeline trapped on its bounds precondition (the Load-button crash in `examples/image`). Zero bounds now release the presentation the same way leaving the window does.

Verified on macOS with `examples/image` built against this branch: the "Photo from URL" section shows the blurred photo with the slider and the Custom URL Loader below it; Load no longer crashes, the loaded photo appears at its decoded size, and its blur slider updates the filter live.
